### PR TITLE
🥅  Add `NotFound` error

### DIFF
--- a/jmapy/errors.py
+++ b/jmapy/errors.py
@@ -1,0 +1,2 @@
+class NotFound(Exception):
+    pass


### PR DESCRIPTION
If the response code is 404, this is called.